### PR TITLE
Hide progress bar when not in verbose mode

### DIFF
--- a/molskill/scorer.py
+++ b/molskill/scorer.py
@@ -65,7 +65,11 @@ class MolSkillScorer:
             num_workers = multiprocessing.cpu_count() // 2
         self.num_workers = num_workers
         self.trainer = pl.Trainer(
-            accelerator="auto", devices=1, max_epochs=-1, logger=verbose, enable_progress_bar=verbose,
+            accelerator="auto",
+            devices=1,
+            max_epochs=-1,
+            logger=verbose,
+            enable_progress_bar=verbose,
         )
 
     def score(

--- a/molskill/scorer.py
+++ b/molskill/scorer.py
@@ -65,7 +65,7 @@ class MolSkillScorer:
             num_workers = multiprocessing.cpu_count() // 2
         self.num_workers = num_workers
         self.trainer = pl.Trainer(
-            accelerator="auto", devices=1, max_epochs=-1, logger=verbose
+            accelerator="auto", devices=1, max_epochs=-1, logger=verbose, enable_progress_bar=verbose,
         )
 
     def score(


### PR DESCRIPTION
Given the intention of `verbose` parameter, I think it makes sense to hide the progress bar when set not to be verbose