### PR TITLE
Hardening publishing pipeline

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,7 +10,6 @@ permissions:
 
 jobs:
   linux:
-    if: ${{ contains(fromJSON(vars.RELEASE_WORKFLOW_ALLOWED_ACTORS || '[]'), github.actor) }}
     environment: conda-release
     runs-on: "ubuntu-latest"
     defaults:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -5,8 +5,13 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   linux:
+    if: ${{ contains(fromJSON(vars.RELEASE_WORKFLOW_ALLOWED_ACTORS || '[]'), github.actor) }}
+    environment: conda-release
     runs-on: "ubuntu-latest"
     defaults:
       run:
@@ -20,7 +25,13 @@ jobs:
           condarc-file: conda-recipe/.condarc
           python-version: 3.9
           auto-activate-base: false
-      - run: |
+      - name: Build and upload conda package
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        run: |
           conda info
           conda install conda-build anaconda-client boa --yes
-          pkgs=$(boa build molskill/conda-recipe/ | grep 'TEST START' | sed 's/TEST START://g') && for pkg in ${pkgs};do anaconda -t ${{ secrets.CONDA_TOKEN }} upload -u msr-ai4science ${pkg}; done
+          pkgs=$(boa build conda-recipe/ | grep 'TEST START' | sed 's/TEST START://g')
+          for pkg in ${pkgs}; do
+            anaconda -t "${ANACONDA_API_TOKEN}" upload -u msr-ai4science "${pkg}"
+          done

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -24,13 +24,16 @@ jobs:
           condarc-file: conda-recipe/.condarc
           python-version: 3.9
           auto-activate-base: false
-      - name: Build and upload conda package
-        env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+      - name: Build conda package
         run: |
           conda info
           conda install conda-build anaconda-client boa --yes
           pkgs=$(boa build conda-recipe/ | grep 'TEST START' | sed 's/TEST START://g')
-          for pkg in ${pkgs}; do
+          echo "BUILT_CONDA_PACKAGES=${pkgs}" >> "$GITHUB_ENV"
+      - name: Publish to Anaconda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        run: |
+          for pkg in ${BUILT_CONDA_PACKAGES}; do
             anaconda -t "${ANACONDA_API_TOKEN}" upload -u msr-ai4science "${pkg}"
           done

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -9,31 +9,64 @@ permissions:
   contents: read
 
 jobs:
-  linux:
-    environment: conda-release
-    runs-on: "ubuntu-latest"
+  build-linux:
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: molskill
           environment-file: environment.yml
           condarc-file: conda-recipe/.condarc
           python-version: 3.9
           auto-activate-base: false
+
       - name: Build conda package
         run: |
           conda info
           conda install conda-build anaconda-client boa --yes
-          pkgs=$(boa build conda-recipe/ | grep 'TEST START' | sed 's/TEST START://g')
-          echo "BUILT_CONDA_PACKAGES=${pkgs}" >> "$GITHUB_ENV"
+          boa build conda-recipe/
+
+      - name: Collect packages
+        run: |
+          mkdir -p dist-conda
+          find "$CONDA_PREFIX/../conda-bld" \
+            \( -name '*.conda' -o -name '*.tar.bz2' \) \
+            -type f \
+            -print \
+            -exec cp {} dist-conda/ \;
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: conda-packages-linux
+          path: dist-conda/*
+
+  publish:
+    needs: build-linux
+    environment: conda-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: conda-packages-linux
+          path: dist-conda
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-activate-base: true
+
+      - name: Install uploader
+        run: conda install anaconda-client --yes
+
       - name: Publish to Anaconda
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         run: |
-          for pkg in ${BUILT_CONDA_PACKAGES}; do
+          shopt -s nullglob
+          for pkg in dist-conda/*.conda dist-conda/*.tar.bz2; do
             anaconda -t "${ANACONDA_API_TOKEN}" upload -u msr-ai4science "${pkg}"
           done


### PR DESCRIPTION
Rotate `CONDA_TOKEN `secret, add environment guard to `conda.yml` workflow, restrict who can trigger the release workflow.