### PR TITLE
skip downloading the moments file again

### DIFF
--- a/molskill/data/standardization.py
+++ b/molskill/data/standardization.py
@@ -29,7 +29,7 @@ def get_population_moments(
         Dict[str, np.ndarray]: population {mean: np.ndarray, std: np.ndarray}
     """
 
-    if moment_csv is None and not os.path.exists(MOMENT_CSV):
+    if moment_csv is None and (not os.path.exists(MOMENT_CSV)) or (os.path.getsize(MOMENT_CSV) == 0):
         LOGGER.info("Standardization moments not found. Downloading from remote...")
         moment_csv = MOMENT_CSV
         os.makedirs(ASSET_PATH, exist_ok=True)

--- a/molskill/data/standardization.py
+++ b/molskill/data/standardization.py
@@ -29,7 +29,7 @@ def get_population_moments(
         Dict[str, np.ndarray]: population {mean: np.ndarray, std: np.ndarray}
     """
 
-    if moment_csv is None:
+    if moment_csv is None and not os.path.exists(MOMENT_CSV):
         LOGGER.info("Standardization moments not found. Downloading from remote...")
         moment_csv = MOMENT_CSV
         os.makedirs(ASSET_PATH, exist_ok=True)

--- a/molskill/data/standardization.py
+++ b/molskill/data/standardization.py
@@ -29,11 +29,12 @@ def get_population_moments(
         Dict[str, np.ndarray]: population {mean: np.ndarray, std: np.ndarray}
     """
 
-    if moment_csv is None and (not os.path.exists(MOMENT_CSV)) or (os.path.getsize(MOMENT_CSV) == 0):
-        LOGGER.info("Standardization moments not found. Downloading from remote...")
+    if moment_csv is None:
         moment_csv = MOMENT_CSV
-        os.makedirs(ASSET_PATH, exist_ok=True)
-        download(DEFAULT_MOMENTS_REMOTE, moment_csv)
+        if (not os.path.exists(moment_csv)) or (os.path.getsize(moment_csv) == 0):
+            LOGGER.info("Standardization moments not found. Downloading from remote...")
+            os.makedirs(ASSET_PATH, exist_ok=True)
+            download(DEFAULT_MOMENTS_REMOTE, moment_csv)
 
     population_df = pd.read_csv(moment_csv, index_col="descriptor")
     assert set(population_df.keys()) == {


### PR DESCRIPTION
The moments file should not be downloaded every time `from molskill.scorer import MolSkillScorer` is run.